### PR TITLE
Fix support for languages other than English

### DIFF
--- a/wagtailcodeblock/blocks.py
+++ b/wagtailcodeblock/blocks.py
@@ -50,8 +50,9 @@ class CodeBlock(StructBlock):
                 help_text=_('Coding language'),
                 label=_('Language'),
                 default=language_default,
+                identifier='language',
             )),
-            ('code', TextBlock(label=_('Code'))),
+            ('code', TextBlock(label=_('Code'), identifier='code')),
         ])
 
         super().__init__(local_blocks, **kwargs)

--- a/wagtailcodeblock/templates/wagtailcodeblock/code_block_form.html
+++ b/wagtailcodeblock/templates/wagtailcodeblock/code_block_form.html
@@ -4,8 +4,8 @@
     }
 
     function populate_target_code(label) {
-        target_class = '#target-element-' + label;
-        code_text = $('#' + label).val();
+        var target_class = '#target-element-' + label;
+        var code_text = $('#' + label).val();
         $(target_class).text(code_text);
         prism_repaint(target_class);
     }
@@ -29,25 +29,25 @@
                 {% endif %}
                 {{ child.render_form }}
             </li>
-            {% if child.block.label == "Language" %}
+            {% if child.block.meta.identifier == "language" %}
                 <script>
                     $(document).ready(function () {
                         // Set initial language class on load
-                        target_class = '#target-element-{{ child.id_for_label }}'.replace('language', 'code');
+                        var target_class = '#target-element-{{ child.id_for_label }}'.replace('language', 'code');
                         {% if child.id_for_label|length %}
                             $(target_class).addClass('language-' + $('#{{ child.id_for_label }}').val());
                         {% endif %}
 
                         // Change language being highlighted when dropdown is changed
                         $('#{{ child.id_for_label }}').bind('input propertychange', function () {
-                            language_class = 'language-' + $('#{{ child.id_for_label }}').val();
+                            var language_class = 'language-' + $('#{{ child.id_for_label }}').val();
                             $(target_class).removeClass().addClass(language_class);
                             prism_repaint(target_class);
                         });
                     });
                 </script>
             {% endif %}
-            {% if child.block.label == "Code" %}
+            {% if child.block.meta.identifier == "code" %}
                 <script>
                     $(document).ready(function () {
                         populate_target_code('{{ child.id_for_label }}');


### PR DESCRIPTION
Currently the code_block_form.html file uses the block.label property to distinguish between two types of blocks "Language" and "Code". This property is however a translatable string. In other languages it doesn't necessarily have the same value. This results in not fully functional code for languages other than English. This PR changes the identifying of the blocks based on a new parameter, which doesn't change in different languages.

PS. I'm not sure why it thinks I changed the whole blocks.py file, I only changed 2 lines. Maybe something with line-breaks?