### PR TITLE
apply update module paths

### DIFF
--- a/tests/migrations/0001_initial.py
+++ b/tests/migrations/0001_initial.py
@@ -2,8 +2,8 @@
 
 from django.db import migrations, models
 import django.db.models.deletion
-import wagtail.core.blocks
-import wagtail.core.fields
+import wagtail.blocks
+import wagtail.fields
 
 
 class Migration(migrations.Migration):
@@ -31,15 +31,15 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "body",
-                    wagtail.core.fields.StreamField(
+                    wagtail.fields.StreamField(
                         [
                             (
                                 "code",
-                                wagtail.core.blocks.StructBlock(
+                                wagtail.blocks.StructBlock(
                                     [
                                         (
                                             "language",
-                                            wagtail.core.blocks.ChoiceBlock(
+                                            wagtail.blocks.ChoiceBlock(
                                                 choices=[
                                                     ("bash", "Bash/Shell"),
                                                     ("css", "CSS"),
@@ -58,7 +58,7 @@ class Migration(migrations.Migration):
                                         ),
                                         (
                                             "code",
-                                            wagtail.core.blocks.TextBlock(
+                                            wagtail.blocks.TextBlock(
                                                 identifier="code", label="Code"
                                             ),
                                         ),

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,7 +1,7 @@
-from wagtail.admin.edit_handlers import StreamFieldPanel
-from wagtail.core.blocks import StreamBlock
-from wagtail.core.fields import StreamField
-from wagtail.core.models import Page
+from wagtail.admin.panels import StreamFieldPanel
+from wagtail.blocks import StreamBlock
+from wagtail.fields import StreamField
+from wagtail.models import Page
 from wagtailcodeblock.blocks import CodeBlock
 
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -24,7 +24,7 @@ INSTALLED_APPS = settings.INSTALLED_APPS + [
     "django.contrib.messages",
     "django.contrib.sessions",
     "django.contrib.staticfiles",
-    "wagtail.core",
+    "wagtail",
     "wagtail.admin",
     "wagtail.documents",
     "tests",
@@ -43,7 +43,7 @@ MIDDLEWARE = settings.MIDDLEWARE + [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "wagtail.core.middleware.SiteMiddleware",
+    "wagtail.middleware.SiteMiddleware",
 ]
 
 ROOT_URLCONF = "tests.urls"

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -2,7 +2,7 @@ from django.urls import include, re_path
 
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.documents import urls as wagtaildocs_urls
-from wagtail.core import urls as wagtail_urls
+from wagtail import urls as wagtail_urls
 
 urlpatterns = [
     re_path(r"^cms/", include(wagtailadmin_urls)),

--- a/wagtailcodeblock/blocks.py
+++ b/wagtailcodeblock/blocks.py
@@ -4,13 +4,13 @@ from django.forms import Media
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
-from wagtail.core.blocks import (
+from wagtail.blocks import (
     StructBlock,
     TextBlock,
     ChoiceBlock,
 )
-from wagtail.core.blocks.struct_block import StructBlockAdapter
-from wagtail.core.telepath import register
+from wagtail.blocks.struct_block import StructBlockAdapter
+from wagtail.telepath import register
 
 from .settings import get_language_choices
 

--- a/wagtailcodeblock/wagtail_hooks.py
+++ b/wagtailcodeblock/wagtail_hooks.py
@@ -1,7 +1,7 @@
 from django.templatetags.static import static
 from django.utils.html import format_html_join
 
-from wagtail.core import hooks
+from wagtail import hooks
 
 from .settings import get_theme, PRISM_VERSION, PRISM_PREFIX
 


### PR DESCRIPTION
Hello @FlipperPA 
As wagtail 3.0, the imports slightly change. I just use the command `updatemodulepaths` from the documentation of wagtail.