### PR TITLE
fix: update deprecated wagtail.telepath import path to wagtail.admin.…

### DIFF
--- a/wagtailcodeblock/blocks.py
+++ b/wagtailcodeblock/blocks.py
@@ -10,7 +10,7 @@ from wagtail.blocks import (
     ChoiceBlock,
 )
 from wagtail.blocks.struct_block import StructBlockAdapter
-from wagtail.telepath import register
+from wagtail.admin.telepath import register
 
 from .settings import get_language_choices
 


### PR DESCRIPTION
## PR Title:
Fix: Update deprecated wagtail.telepath import path

## PR Description:
### Description
This PR updates the import path for the `register` function from `wagtail.telepath` to `wagtail.admin.telepath` to address a deprecation warning. This change ensures compatibility with future Wagtail 8.0 releases.

### Changes Made
- Updated import statement in [wagtailcodeblock/blocks.py](cci:7://file:///Users/nonso/code/tuts/wagtailcodeblock/wagtailcodeblock/blocks.py:0:0-0:0) from `wagtail.telepath` to `wagtail.admin.telepath`

### Reason for Change
The current import path is triggering the following deprecation warning:
```
RemovedInWagtail80Warning: wagtail.telepath has been moved to wagtail.admin.telepath
```

This change proactively addresses the warning to ensure the codebase remains compatible with future Wagtail versions.

### Testing
- Verified that the code continues to function as expected after the import path change

### Related Issues
[https://github.com/FlipperPA/wagtailcodeblock/issues/49](https://github.com/FlipperPA/wagtailcodeblock/issues/49)
