### PR TITLE
fix: fix min version wagtail

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
 ]
 dependencies = [
-    "wagtail>=6",
+    "wagtail>=7.1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
The move of telepath from `wagtail.telepath` to `wagtail.admin.telepath` has been introduced only in version wagtail `7.1`

https://docs.wagtail.org/en/latest/releases/7.1.html#wagtail-telepath-and-wagtail-widget-adapters-moved-to-wagtail-admin-telepath

Therefore, for the fix introduced in https://github.com/wagtail-nest/wagtailcodeblock/pull/50, we need to set the min version of wagtail to `7.1`. Otherwise, with older version, we discover only at runtime the `ModuleNotFoundError: No module named 'wagtail.admin.telepath'` and it would be better to discover it at build time.

I don't know if you have the possibility to update the version `1.30.0.0` to include this fix. 